### PR TITLE
refactor: move `Measurement` struct to its own header file

### DIFF
--- a/include/influxdb.h
+++ b/include/influxdb.h
@@ -1,6 +1,7 @@
 #ifndef INFLUXDB_H
 #define INFLUXDB_H
 
+#include "measurement.h"
 #include "utils.h"
 
 /**

--- a/include/measurement.h
+++ b/include/measurement.h
@@ -1,0 +1,31 @@
+#ifndef MEASUREMENT_H
+#define MEASUREMENT_H
+
+#include <memory>
+
+/**
+ * Represents a measurement of various weather parameters
+ *
+ * This struct holds smart pointers to float values for different weather data.
+ * Using std::unique_ptr makes sure the memory is cleaned up automatically.
+ * If a pointer is null, it means that the measurement was not taken or is invalid.
+ */
+struct Measurement {
+    std::unique_ptr<float> temperature_c;
+    std::unique_ptr<float> temperature_f;
+    std::unique_ptr<float> humidity;
+    std::unique_ptr<float> pressure_hpa;
+    std::unique_ptr<float> pressure_b;
+    std::unique_ptr<float> dew_point_c;
+    std::unique_ptr<float> dew_point_f;
+    std::unique_ptr<float> illumination;
+    std::unique_ptr<float> battery_voltage;
+    std::unique_ptr<float> solar_panel_voltage;
+
+    Measurement();
+    void calculateDerivedValues();
+    void remove_invalid_measurements();
+    bool hasSensorData() const;
+};
+
+#endif // MEASUREMENT_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -3,54 +3,12 @@
 
 #include <Arduino.h>
 
-#include <memory>
-
 extern String log_buffer;
-
-/**
- * Represents a measurement of various weather parameters
- *
- * This struct holds smart pointers to float values for different weather data.
- * Using std::unique_ptr makes sure the memory is cleaned up automatically.
- * If a pointer is null, it means that the measurement was not taken or is invalid.
- */
-struct Measurement {
-    std::unique_ptr<float> temperature_c;
-    std::unique_ptr<float> temperature_f;
-    std::unique_ptr<float> humidity;
-    std::unique_ptr<float> pressure_hpa;
-    std::unique_ptr<float> pressure_b;
-    std::unique_ptr<float> dew_point_c;
-    std::unique_ptr<float> dew_point_f;
-    std::unique_ptr<float> illumination;
-    std::unique_ptr<float> battery_voltage;
-    std::unique_ptr<float> solar_panel_voltage;
-
-    Measurement();
-    void calculateDerivedValues();
-    void remove_invalid_measurements();
-    bool hasSensorData() const;
-};
 
 /**
  * Logs a message to both the serial output and an internal log buffer
  */
 void serial_log(String message);
-
-/**
- * Calculates the dew point temperature from temperature and humidity
- *
- * Uses the Magnus formula to calculate the dew point temperature. The dew point is the temperature
- * the air needs to be cooled to (at constant pressure) in order to produce a relative humidity of
- * 100%.
- *
- * Reference: https://en.wikipedia.org/wiki/Dew_point
- *
- * @param temperature Temperature in degrees Celsius
- * @param humidity Relative humidity as a percentage (0-100)
- * @return Dew point temperature in degrees Celsius
- */
-float calculate_dew_point(float temperature, float humidity);
 
 /**
  * Isolates all RTC-capable GPIO pins to reduce power consumption

--- a/include/wunderground.h
+++ b/include/wunderground.h
@@ -1,6 +1,7 @@
 #ifndef WUNDERGROUND_H
 #define WUNDERGROUND_H
 
+#include "measurement.h"
 #include "utils.h"
 
 /**

--- a/src/influxdb.cpp
+++ b/src/influxdb.cpp
@@ -1,4 +1,6 @@
+#include "influxdb.h"
 #include "env.h"
+#include "measurement.h"
 #include "utils.h"
 
 #include <HTTPClient.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 
 #include "env.h"
 #include "influxdb.h"
+#include "measurement.h"
 #include "utils.h"
 #include "wunderground.h"
 

--- a/src/measurement.cpp
+++ b/src/measurement.cpp
@@ -1,0 +1,76 @@
+#include "measurement.h"
+#include <math.h>
+
+static float calculate_dew_point(float temperature, float humidity);
+
+Measurement::Measurement()
+    : temperature_c(nullptr)
+    , temperature_f(nullptr)
+    , humidity(nullptr)
+    , pressure_hpa(nullptr)
+    , pressure_b(nullptr)
+    , dew_point_c(nullptr)
+    , dew_point_f(nullptr)
+    , illumination(nullptr)
+    , battery_voltage(nullptr)
+    , solar_panel_voltage(nullptr)
+{
+}
+
+void Measurement::calculateDerivedValues()
+{
+    if (temperature_c) {
+        temperature_f = std::make_unique<float>(*temperature_c * 9.0f / 5.0f + 32.0f);
+        if (humidity) {
+            dew_point_c = std::make_unique<float>(calculate_dew_point(*temperature_c, *humidity));
+            dew_point_f = std::make_unique<float>(*dew_point_c * 9.0f / 5.0f + 32.0f);
+        }
+    }
+    if (pressure_hpa) {
+        pressure_b = std::make_unique<float>(*pressure_hpa * 0.02953f);
+    }
+}
+
+void Measurement::remove_invalid_measurements()
+{
+    // TODO: link to data sheet for each sensor about valid ranges
+    if (temperature_c)
+        if (*temperature_c < -40 || *temperature_c > 85)
+            temperature_c = nullptr;
+    if (humidity)
+        if (*humidity < 0 || *humidity > 100)
+            humidity = nullptr;
+    if (pressure_hpa)
+        if (*pressure_hpa < 300 || *pressure_hpa > 1100)
+            pressure_hpa = nullptr;
+    if (illumination)
+        if (*illumination < 0 || *illumination > 100000)
+            illumination = nullptr;
+}
+
+bool Measurement::hasSensorData() const
+{
+    // we generally don't want to send data if we don't have at least one sensor reading
+    return temperature_c != nullptr || humidity != nullptr || pressure_hpa != nullptr || illumination != nullptr;
+}
+
+/**
+ * Calculates the dew point temperature from temperature and humidity
+ *
+ * Uses the Magnus formula to calculate the dew point temperature. The dew point is the temperature
+ * the air needs to be cooled to (at constant pressure) in order to produce a relative humidity of
+ * 100%.
+ *
+ * Reference: https://en.wikipedia.org/wiki/Dew_point
+ *
+ * @param temperature Temperature in degrees Celsius
+ * @param humidity Relative humidity as a percentage (0-100)
+ * @return Dew point temperature in degrees Celsius
+ */
+static float calculate_dew_point(float temperature, float humidity)
+{
+    const float b = 17.62;
+    const float c = 243.12;
+    float alpha = ((b * temperature) / (c + temperature)) + log(humidity / 100.0);
+    return (c * alpha) / (b - alpha);
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,69 +9,10 @@
 
 String log_buffer = "";
 
-Measurement::Measurement()
-    : temperature_c(nullptr)
-    , temperature_f(nullptr)
-    , humidity(nullptr)
-    , pressure_hpa(nullptr)
-    , pressure_b(nullptr)
-    , dew_point_c(nullptr)
-    , dew_point_f(nullptr)
-    , illumination(nullptr)
-    , battery_voltage(nullptr)
-    , solar_panel_voltage(nullptr)
-{
-}
-
-void Measurement::calculateDerivedValues()
-{
-    if (temperature_c) {
-        temperature_f = std::make_unique<float>(*temperature_c * 9.0f / 5.0f + 32.0f);
-        if (humidity) {
-            dew_point_c = std::make_unique<float>(calculate_dew_point(*temperature_c, *humidity));
-            dew_point_f = std::make_unique<float>(*dew_point_c * 9.0f / 5.0f + 32.0f);
-        }
-    }
-    if (pressure_hpa) {
-        pressure_b = std::make_unique<float>(*pressure_hpa * 0.02953f);
-    }
-}
-
-void Measurement::remove_invalid_measurements()
-{
-    // TODO: link to data sheet for each sensor about valid ranges
-    if (temperature_c)
-        if (*temperature_c < -40 || *temperature_c > 85)
-            temperature_c = nullptr;
-    if (humidity)
-        if (*humidity < 0 || *humidity > 100)
-            humidity = nullptr;
-    if (pressure_hpa)
-        if (*pressure_hpa < 300 || *pressure_hpa > 1100)
-            pressure_hpa = nullptr;
-    if (illumination)
-        if (*illumination < 0 || *illumination > 100000)
-            illumination = nullptr;
-}
-
-bool Measurement::hasSensorData() const
-{
-    // we generally don't want to send data if we don't have at least one sensor reading
-    return temperature_c != nullptr || humidity != nullptr || pressure_hpa != nullptr || illumination != nullptr;
-}
-
 void serial_log(String message)
 {
     log_buffer += message + "\n";
     Serial.println(message);
-}
-
-float calculate_dew_point(float temperature, float humidity)
-{
-    const float b = 17.62;
-    const float c = 243.12;
-    float alpha = ((b * temperature) / (c + temperature)) + log(humidity / 100.0);
-    return (c * alpha) / (b - alpha);
 }
 
 void isolate_all_rtc_gpio()

--- a/src/wunderground.cpp
+++ b/src/wunderground.cpp
@@ -1,4 +1,6 @@
+#include "wunderground.h"
 #include "env.h"
+#include "measurement.h"
 #include "utils.h"
 
 #include <HTTPClient.h>


### PR DESCRIPTION
Split out the `Measurement` struct from utils into a dedicated measurement module. Also moved `calculate_dew_point` into the measurement implementation as a static function since it's only used there.